### PR TITLE
Update trino-client to v0.1.10

### DIFF
--- a/package.json
+++ b/package.json
@@ -54,7 +54,7 @@
   "dependencies": {
     "@sqltools/base-driver": "latest",
     "@sqltools/types": "latest",
-    "trino-client": "^0.1.9",
+    "trino-client": "^0.1.10",
     "uuid": "^8.3.2"
   },
   "devDependencies": {

--- a/yarn.lock
+++ b/yarn.lock
@@ -2776,10 +2776,10 @@ to-regex-range@^5.0.1:
   dependencies:
     is-number "^7.0.0"
 
-trino-client@^0.1.9:
-  version "0.1.9"
-  resolved "https://registry.yarnpkg.com/trino-client/-/trino-client-0.1.9.tgz#d39080715c666adbd418d580dff41775d47a4846"
-  integrity sha512-CDTtNwcULSOgcx+fwooSJVFk9bRPsiTmET3BH1o/R2q9XZb9sG50l3AD6ncvZTPV8m7zp39ttXmXd2PGADQ0dg==
+trino-client@^0.1.10:
+  version "0.1.10"
+  resolved "https://registry.yarnpkg.com/trino-client/-/trino-client-0.1.10.tgz#f05258ae09f66278bc35113a8bc87f6a0f547add"
+  integrity sha512-+zZzX36FPpgGenxojQ5/nT9hhvjqIwcgdh9xhJjCgfW9er+TEktN5LsLKrOw1jz2v3lOJ6RybpXYrCrcqMInaw==
   dependencies:
     axios "^0.27.2"
 


### PR DESCRIPTION
This client version adds propper support for prepared statements.