### PR TITLE
added client tag as as optional for establishing connection with tags option

### DIFF
--- a/connection.schema.json
+++ b/connection.schema.json
@@ -23,6 +23,10 @@
       "type": "string",
       "minLength": 1
     },
+    "clientTags": {
+      "title": "clientTags",
+      "type": "string"
+    },
     "trinoOptions": {
       "type": "object",
       "title": "Trino Options",

--- a/src/ls/driver.ts
+++ b/src/ls/driver.ts
@@ -34,6 +34,7 @@ export default class TrinoDriver
       source: "sqltools-driver",
       auth: new BasicAuth(this.credentials.user, this.credentials.password),
       ssl: this.credentials.trinoOptions?.ssl, 
+      client_tags: this.credentials.client_tags,
     };
 
     try {

--- a/src/ls/driver.ts
+++ b/src/ls/driver.ts
@@ -34,7 +34,7 @@ export default class TrinoDriver
       source: "sqltools-driver",
       auth: new BasicAuth(this.credentials.user, this.credentials.password),
       ssl: this.credentials.trinoOptions?.ssl, 
-      client_tags: this.credentials.client_tags,
+      client_tags: this.credentials.clientTags,
     };
 
     try {

--- a/ui.schema.json
+++ b/ui.schema.json
@@ -5,6 +5,7 @@
     "schema",
     "user",
     "password",
+    "clientTags",
     "trinoOptions"
   ],
   "password": {


### PR DESCRIPTION
We use client_tags for query cost attribution, having it as optional parameter in connection config will not break anything  backward.